### PR TITLE
Add overlay mode toggle with opt+p hotkey

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -416,6 +416,16 @@ function obj:stop()
     return self
 end
 
+function obj:toggleOverlay()
+    local enabled = webviewModule.toggleOverlay(log)
+    if enabled then
+        hs.alert.show("Overlay mode ON", 1)
+    else
+        hs.alert.show("Overlay mode OFF", 1)
+    end
+    return self
+end
+
 function obj:configure(options)
     if options then
         for k, v in pairs(options) do
@@ -482,7 +492,8 @@ end
 
 obj.defaultHotkeys = {
     toggle = {{"alt"}, "."},
-    status = {{"cmd", "alt"}, "T"}
+    status = {{"cmd", "alt"}, "T"},
+    overlay = {{"alt"}, "p"}
 }
 
 function obj:bindHotkeys(mapping)
@@ -495,7 +506,8 @@ function obj:bindHotkeys(mapping)
                 status.taskCount, status.pending, status.inProgress, status.completed
             )
             hs.alert.show(msg, 3)
-        end
+        end,
+        overlay = function() obj:toggleOverlay() end
     }
     hs.spoons.bindHotkeysToSpec(def, mapping)
     return self

--- a/lib/webview.lua
+++ b/lib/webview.lua
@@ -10,6 +10,7 @@ local detailWebview = nil
 local quickTaskWebview = nil
 local quickTaskUserContent = nil
 local isVisible = false
+local isOverlayMode = false
 
 -- Create user content controller for JS-Lua bridge
 function M.createUserContent(actionHandler, log)
@@ -587,6 +588,30 @@ function M.closeQuickTaskDialog()
     end
 end
 
+-- Toggle overlay mode (semi-transparent passthrough)
+function M.toggleOverlay(log)
+    if not webview then return false end
+
+    isOverlayMode = not isOverlayMode
+
+    if isOverlayMode then
+        webview:alpha(0.3)
+        webview:behavior({"canJoinAllSpaces", "stationary"})
+        log("Overlay mode enabled")
+    else
+        webview:alpha(0.98)
+        webview:behavior({})
+        log("Overlay mode disabled")
+    end
+
+    return isOverlayMode
+end
+
+-- Check overlay mode
+function M.isOverlayMode()
+    return isOverlayMode
+end
+
 -- Cleanup all webviews
 function M.cleanup()
     if webview then
@@ -604,6 +629,7 @@ function M.cleanup()
     usercontent = nil
     quickTaskUserContent = nil
     isVisible = false
+    isOverlayMode = false
 end
 
 return M


### PR DESCRIPTION
## Summary
- opt+p 단축키로 반투명 오버레이 모드 토글 기능 추가
- 오버레이 모드 시 alpha 0.3으로 투명화, stationary behavior로 다른 창 위에 고정
- toggleOverlay() 메서드 및 isOverlayMode() 상태 확인 함수 추가

## Test plan
- [x] Hammerspoon 콘솔에서 Spoon 리로드
- [x] opt+p로 오버레이 모드 ON/OFF 토글 확인
- [x] 오버레이 모드에서 투명도 및 창 고정 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)