### PR TITLE
fix(tasks): handle dots in filenames when decoding CWD path

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,13 +79,21 @@ Tasks are stored in `~/.claude/tasks/{sessionId}/*.json`. Each session directory
 
 ### CWD Path Encoding
 
-Claude Code encodes working directory paths in session IDs where `/` → `-` and `/.` → `--`. The `tasks.decodeCwdPath()` function resolves ambiguity (e.g., `team-attention` directory name vs `/team/attention` path) by walking the filesystem to find valid paths. This is critical for the "Launch Claude" feature.
+Claude Code encodes working directory paths in session IDs:
+- `/` → `-` (path separator)
+- `.` → `-` (dot in filenames, e.g., `ClaudeTasks.spoon` → `ClaudeTasks-spoon`)
+- `/.` → `--` (dot directories, e.g., `/.claude` → `--claude`)
+
+The `tasks.decodeCwdPath()` function resolves ambiguity by backtracking through all interpretations of `-` (as `/`, `.`, or literal `-`) and validating against the filesystem. This is critical for the "Launch Claude" feature.
 
 ## Development Commands
 
-No build/test/lint commands. This is a pure Lua Spoon.
+**Unit tests**: Run with pure Lua (no Hammerspoon required):
+```bash
+lua tests/test_tasks.lua
+```
 
-**Testing**: Reload in Hammerspoon console with:
+**Integration testing**: Reload in Hammerspoon console:
 ```lua
 hs.loadSpoon("ClaudeTasks")
 spoon.ClaudeTasks:start()

--- a/tests/test_tasks.lua
+++ b/tests/test_tasks.lua
@@ -1,0 +1,163 @@
+-- tests/test_tasks.lua
+-- Unit tests for lib/tasks.lua (decodeCwdPath)
+-- Run with: lua tests/test_tasks.lua
+
+local TEST_PASSED = 0
+local TEST_FAILED = 0
+
+-- Mock filesystem for testing
+local mockFs = {}
+
+local function setMockFs(paths)
+    mockFs = {}
+    for _, path in ipairs(paths) do
+        mockFs[path] = "directory"
+    end
+end
+
+-- Mock hs.fs.attributes
+hs = {
+    fs = {
+        attributes = function(path, attr)
+            if attr == "mode" then
+                return mockFs[path]
+            end
+            return nil
+        end
+    }
+}
+
+-- Load the tasks module
+local function loadTasks()
+    local path = debug.getinfo(1, "S").source:sub(2)
+    local dir = path:match("(.*/)")
+    local f, err = loadfile(dir .. "../lib/tasks.lua")
+    if not f then error("Failed to load tasks.lua: " .. err) end
+    return f()
+end
+
+local tasks = loadTasks()
+
+-- Test helper
+local function test(name, fn)
+    local ok, err = pcall(fn)
+    if ok then
+        TEST_PASSED = TEST_PASSED + 1
+        print("✓ " .. name)
+    else
+        TEST_FAILED = TEST_FAILED + 1
+        print("✗ " .. name)
+        print("  Error: " .. tostring(err))
+    end
+end
+
+local function assertEqual(actual, expected, msg)
+    if actual ~= expected then
+        error(string.format("%s\n  Expected: %s\n  Actual:   %s",
+            msg or "Assertion failed", tostring(expected), tostring(actual)))
+    end
+end
+
+-- Test cases
+print("\n=== decodeCwdPath Tests ===\n")
+
+test("Simple path: /Users/choi", function()
+    setMockFs({"/Users", "/Users/choi"})
+    local result = tasks.decodeCwdPath("-Users-choi")
+    assertEqual(result, "/Users/choi")
+end)
+
+test("Path with dot directory: /Users/choi/.claude", function()
+    setMockFs({"/Users", "/Users/choi", "/Users/choi/.claude"})
+    local result = tasks.decodeCwdPath("-Users-choi--claude")
+    assertEqual(result, "/Users/choi/.claude")
+end)
+
+test("Path with dot in dirname: ClaudeTasks.spoon", function()
+    setMockFs({
+        "/Users", "/Users/choi", "/Users/choi/Downloads",
+        "/Users/choi/Downloads/github", "/Users/choi/Downloads/github/private",
+        "/Users/choi/Downloads/github/private/ClaudeTasks.spoon"
+    })
+    local result = tasks.decodeCwdPath("-Users-choi-Downloads-github-private-ClaudeTasks-spoon")
+    assertEqual(result, "/Users/choi/Downloads/github/private/ClaudeTasks.spoon")
+end)
+
+test("Path with hyphen in dirname: my-project", function()
+    setMockFs({
+        "/Users", "/Users/choi", "/Users/choi/my-project"
+    })
+    local result = tasks.decodeCwdPath("-Users-choi-my-project")
+    assertEqual(result, "/Users/choi/my-project")
+end)
+
+test("Path with multiple hyphens: aqueduct-deploy", function()
+    setMockFs({
+        "/Users", "/Users/choi", "/Users/choi/Downloads",
+        "/Users/choi/Downloads/github", "/Users/choi/Downloads/github/private",
+        "/Users/choi/Downloads/github/private/aqueduct-deploy"
+    })
+    local result = tasks.decodeCwdPath("-Users-choi-Downloads-github-private-aqueduct-deploy")
+    assertEqual(result, "/Users/choi/Downloads/github/private/aqueduct-deploy")
+end)
+
+test("Hidden directory at start: /.config", function()
+    setMockFs({"/.config"})
+    local result = tasks.decodeCwdPath("--config")
+    assertEqual(result, "/.config")
+end)
+
+test("Multiple dots: file.test.spoon", function()
+    setMockFs({
+        "/Users", "/Users/choi", "/Users/choi/file.test.spoon"
+    })
+    local result = tasks.decodeCwdPath("-Users-choi-file-test-spoon")
+    assertEqual(result, "/Users/choi/file.test.spoon")
+end)
+
+test("Mixed hyphen and dot: my-app.spoon", function()
+    setMockFs({
+        "/Users", "/Users/choi", "/Users/choi/my-app.spoon"
+    })
+    local result = tasks.decodeCwdPath("-Users-choi-my-app-spoon")
+    assertEqual(result, "/Users/choi/my-app.spoon")
+end)
+
+test("Nested dot directories: /Users/choi/.config/.local", function()
+    setMockFs({
+        "/Users", "/Users/choi", "/Users/choi/.config",
+        "/Users/choi/.config/.local"
+    })
+    local result = tasks.decodeCwdPath("-Users-choi--config--local")
+    assertEqual(result, "/Users/choi/.config/.local")
+end)
+
+test("Ambiguous: prefers existing path (hyphen exists, dot doesn't)", function()
+    setMockFs({
+        "/Users", "/Users/choi", "/Users/choi/foo-bar"
+        -- /Users/choi/foo.bar does NOT exist
+    })
+    local result = tasks.decodeCwdPath("-Users-choi-foo-bar")
+    assertEqual(result, "/Users/choi/foo-bar")
+end)
+
+test("Ambiguous: prefers existing path (dot exists, hyphen doesn't)", function()
+    setMockFs({
+        "/Users", "/Users/choi", "/Users/choi/foo.bar"
+        -- /Users/choi/foo-bar does NOT exist
+    })
+    local result = tasks.decodeCwdPath("-Users-choi-foo-bar")
+    assertEqual(result, "/Users/choi/foo.bar")
+end)
+
+test("Non-existent path returns nil", function()
+    setMockFs({"/Users", "/Users/choi"})
+    local result = tasks.decodeCwdPath("-Users-choi-nonexistent")
+    assertEqual(result, nil)
+end)
+
+-- Summary
+print(string.format("\n=== Results: %d passed, %d failed ===\n",
+    TEST_PASSED, TEST_FAILED))
+
+os.exit(TEST_FAILED > 0 and 1 or 0)


### PR DESCRIPTION
## Summary
- Claude encodes `.` in filenames as `-` (e.g., `ClaudeTasks.spoon` → `ClaudeTasks-spoon`)
- Previous implementation only handled `/.` → `--` for dot directories
- Rewrote `decodeCwdPath()` with backtracking algorithm that tries all interpretations of `-` (as `/`, `.`, or literal `-`) and validates against filesystem

## Test plan
- [x] Unit tests pass: `lua tests/test_tasks.lua` (12 test cases)
- [x] Manual test: Reload spoon in Hammerspoon and verify CWD resolution for `ClaudeTasks.spoon` path

🤖 Generated with [Claude Code](https://claude.com/claude-code)