### PR TITLE
fix(task-save): remove invalid hooks reference from plugin.json

### DIFF
--- a/task-save/.claude-plugin/plugin.json
+++ b/task-save/.claude-plugin/plugin.json
@@ -5,6 +5,5 @@
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"
-  },
-  "hooks": "../hooks/hooks.json"
+  }
 }


### PR DESCRIPTION
## Summary
- Remove invalid `hooks` string path reference from plugin.json
- Claude Code plugins auto-discover hooks from conventional `hooks/hooks.json` path
- Fixes "hooks: Invalid input" validation error during plugin installation

## Test plan
- [ ] Verify no validation errors
- [ ] Verify PostToolUse hook is active

🤖 Generated with [Claude Code](https://claude.com/claude-code)