### PR TITLE
feat: add cross-project handoff support

### DIFF
--- a/task-save/.claude-plugin/plugin.json
+++ b/task-save/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "task-save",
   "description": "Capture conversation context as structured tasks with current status and next steps",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "author": {
     "name": "Jongwon Choi",
     "url": "https://github.com/jongwony"

--- a/task-save/skills/task-save/SKILL.md
+++ b/task-save/skills/task-save/SKILL.md
@@ -3,8 +3,10 @@ name: task-save
 description: |
   This skill should be used when the user asks to "save current task", "save progress",
   "create task from context", "task-save", or wants to capture current work state.
-  Usage: /task-save [query] - optional topic filter; uses full conversation context if omitted.
+  Usage: /task-save [--cwd <path>] [query]
+  --cwd: Cross-project handoff (records target directory in metadata for ClaudeTasks.spoon).
 user-invocable: true
+argument-hint: "[--cwd <path>] [query]"
 ---
 
 # Task Save
@@ -20,8 +22,16 @@ Transform conversation context into actionable task entries by:
 
 ## Input
 
-- `$ARGUMENTS`: Optional topic filter. If provided, focus extraction on this topic.
-- If omitted, analyze entire recent conversation.
+- `$ARGUMENTS`: Optional flags and topic filter.
+  - `--cwd <path>`: Cross-project handoff. The path is the target project directory (absolute or relative).
+  - Remaining arguments: topic filter. If omitted, analyze entire recent conversation.
+
+## Argument Parsing
+
+Parse `$ARGUMENTS` for `--cwd`:
+1. If `--cwd <path>` is present, extract the path and resolve to absolute path using Bash `realpath`.
+2. Remaining arguments after `--cwd <path>` become the topic filter.
+3. If `--cwd` is absent, behave as normal task-save.
 
 ## Output
 
@@ -32,7 +42,29 @@ Create a single TaskCreate with:
 | **subject** | Imperative verb phrase (task goal) |
 | **description** | `**Current Status**: ...`<br>`**Next Steps**: ...` |
 | **activeForm** | Present continuous form (spinner display) |
-| **metadata** | Optional context (e.g., `source: "slack"`, `topic: "..."`) |
+| **metadata** | Context fields (see below) |
+
+### Metadata Schema
+
+**Standard** (no `--cwd`):
+```json
+{"source": "task-save", "topic": "..."}
+```
+
+**Handoff** (with `--cwd`):
+```json
+{
+  "source": "task-save",
+  "handoff": true,
+  "target_cwd": "/absolute/path/to/target",
+  "source_cwd": "/absolute/path/to/current"
+}
+```
+
+- `target_cwd`: resolved absolute path from `--cwd` argument
+- `source_cwd`: current working directory (`$PWD`) at handoff time
+
+When `handoff: true`, ClaudeTasks.spoon renders the task with a distinct handoff launcher that opens a new Claude session in `target_cwd` with a fresh `CLAUDE_CODE_TASK_LIST_ID`.
 
 ## Extraction Sources
 
@@ -46,3 +78,4 @@ Create a single TaskCreate with:
 - Single focused task per invocation
 - Adapt structure to user's additional instructions if provided
 - If context insufficient, ask user for clarification before creating task
+- For `--cwd`: validate the path exists before creating the task


### PR DESCRIPTION
## Summary

- **task-save skill**: `--cwd <path>` 인자 추가로 cross-project handoff 지원. metadata에 `handoff: true`, `target_cwd`, `source_cwd` 기록
- **ClaudeTasks.spoon UI**: handoff task 감지 시 보라색 ⤴ 버튼 표시, 클릭하면 target cwd에서 같은 task list를 공유하는 새 Claude 세션 실행
- **리팩토링**: launch 버튼/cwd 표시 로직을 `generateLaunchBtn()`, `generateCwdDisplay()` helper로 추출 (3곳 중복 제거)
- task-save plugin version bump `1.1.1` → `1.2.0`

## Test plan

- [x] `/task-save --cwd ../cc-plugin <context>` 실행 후 handoff metadata가 포함된 task 생성 확인
- [x] ClaudeTasks.spoon에서 handoff task에 보라색 ⤴ 버튼 및 target_cwd 경로 표시 확인
- [x] ⤴ 버튼 클릭 시 target cwd에서 동일 CLAUDE_CODE_TASK_LIST_ID로 새 Claude 세션 실행 확인
- [x] 기존 ▶ 버튼(일반 task) 동작에 영향 없음 확인
- [x] `lua tests/test_tasks.lua` 단위 테스트 통과 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)