### PR TITLE
feat: session badge 클릭으로 환경변수 클립보드 복사

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -259,6 +259,11 @@ local function actionHandler(action, params)
         obj:launchClaudeWithCwd(params.sessionId, params.cwd)
     elseif action == "launchClaudeWithSession" then
         obj:launchClaudeWithSession(params.sessionId)
+    elseif action == "copySessionEnv" then
+        local val = "CLAUDE_CODE_TASK_LIST_ID=" .. (params.sessionId or "")
+        if not hs.pasteboard.setContents(val) then
+            log("copySessionEnv: pasteboard write failed")
+        end
     elseif action == "showQuickUpdateDialog" then
         obj:showQuickTaskDialog()
     elseif action == "launchClaudeHandoff" then

--- a/lib/html.lua
+++ b/lib/html.lua
@@ -174,8 +174,9 @@ function M.generateTaskCard(task, utils, options)
     if descriptionHtml ~= '' then
         h = h .. '        ' .. descriptionHtml .. '\n'
     end
+    local sessionJson = utils.jsonEncodeString(task._sessionId or '')
     h = h .. '        <div class="task-meta">#' .. utils.escapeHtml(tostring(task.id))
-        .. ' <span class="session-badge" title="' .. utils.escapeHtml(task._sessionId) .. '">'
+        .. ' <span class="session-badge" title="' .. utils.escapeHtml('CLAUDE_CODE_TASK_LIST_ID=' .. (task._sessionId or '')) .. '" onclick=\'copySessionEnv(' .. sessionJson .. ', this); event.stopPropagation();\'>'
         .. utils.escapeHtml(task._sessionId) .. '</span>' .. ownerHtml .. '</div>\n'
     if metadataHtml ~= '' then
         h = h .. '        <div class="task-meta">' .. metadataHtml .. '</div>\n'
@@ -531,6 +532,12 @@ function M.generateHTML(opts)
             padding: 2px 6px;
             border-radius: 4px;
             color: #888;
+            cursor: pointer;
+            transition: background 0.15s;
+        }
+        .session-badge:hover {
+            background: rgba(255, 255, 255, 0.2);
+            color: #aaa;
         }
         .owner-badge {
             font-size: 10px;
@@ -1226,6 +1233,24 @@ function M.generateHTML(opts)
                 action: 'launchClaudeWithSession',
                 sessionId: sessionId
             });
+        }
+
+        function copySessionEnv(sessionId, el) {
+            window.webkit.messageHandlers.taskBridge.postMessage({
+                action: 'copySessionEnv',
+                sessionId: sessionId
+            });
+            if (el._copying) return;
+            el._copying = true;
+            var original = el.textContent;
+            var w = el.offsetWidth;
+            el.style.minWidth = w + 'px';
+            el.textContent = 'Copied!';
+            setTimeout(function() {
+                el.textContent = original;
+                el.style.minWidth = '';
+                el._copying = false;
+            }, 1500);
         }
 
         function showQuickUpdateDialog() {


### PR DESCRIPTION
## Summary

- Session badge 클릭 시 `CLAUDE_CODE_TASK_LIST_ID=<session_id>` 문자열을 클립보드에 복사
- "Copied!" 텍스트 피드백 1.5초 표시 후 원래 session ID로 복원
- `offsetWidth` 캡처 → `min-width` 고정으로 레이아웃 시프트 방지
- Rapid-click guard(`el._copying`)로 중복 클릭 시 텍스트 고착 방지
- Badge에 `cursor:pointer` + hover 효과 추가로 클릭 어포던스 제공
- Tooltip에 복사될 환경변수 문자열 미리보기 표시

## Test plan

- [x] Session badge 호버 시 커서 변경 및 배경 밝기 효과 확인
- [x] Badge 클릭 → 클립보드에 `CLAUDE_CODE_TASK_LIST_ID=<id>` 복사 확인 (터미널에서 pbpaste)
- [x] "Copied!" 텍스트 1.5초 표시 후 원래 ID 복원 확인
- [x] 레이아웃 시프트 없음 확인 (badge 너비 유지)
- [x] 1.5초 내 연속 클릭 시 텍스트 고착 없음 확인
- [x] 기존 ▶ launch 버튼 정상 동작 확인
- [x] Search/Projects/Tasks 탭 모두에서 동작 확인
- [x] `lua tests/test_tasks.lua` 단위 테스트 통과 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)







