### PR TITLE
fix: ship 스킬 ci 타입 task 기본 제외

### DIFF
--- a/task-workflow/skills/ship/SKILL.md
+++ b/task-workflow/skills/ship/SKILL.md
@@ -57,6 +57,7 @@ Task behavior: can be executed by `/task-run --all` in the current or next sessi
 **Priority 2 — `ci`**: Item depends on CI pipeline results.
 Detection: contains "CI", "pipeline", "workflow", "review pass", "GitHub Actions" AND no backtick-wrapped executable command matching Priority 1 patterns.
 Task behavior: verify via `gh run list` or `gh pr checks` after push.
+Default: excluded from task creation (CI results are auto-verifiable). Shown in Phase 4 for transparency; user can opt-in.
 
 **Priority 3 — `post-merge`**: Item requires merge or a separate session to verify.
 Detection: no executable command (Priority 1) AND no CI keywords (Priority 2) AND contains keywords indicating post-merge context — new session, reload, restart, next session, after merge, plugin reload, routing, deploy (in any language matching the PR body).
@@ -68,7 +69,7 @@ Task behavior: surfaced in ClaudePanel for user to manually check off.
 
 ### Phase 4: User Confirmation
 
-Present the classified items via `AskUserQuestion`. Group items by type, showing the count per type and listing each item under its classification.
+Present the classified items via `AskUserQuestion`. Group items by type, showing the count per type and listing each item under its classification. ci-type items are shown separately as excluded by default — CI results are auto-verifiable via `gh pr checks`. The user can include specific ci items if manual tracking is desired.
 
 The user can:
 - Confirm as-is
@@ -78,7 +79,7 @@ The user can:
 
 ### Phase 5: Create Tasks
 
-For each confirmed item (using the user's final classifications after any reclassification in Phase 4), call `TaskCreate`:
+For each confirmed item (using the user's final classifications after any reclassification in Phase 4), call `TaskCreate`. ci-type items excluded by default. Only create ci tasks if the user explicitly opted them in during Phase 4.
 
 | Field | Value |
 |-------|-------|
@@ -92,7 +93,10 @@ For each confirmed item (using the user's final classifications after any reclas
 
 **Batch creation**: TaskCreate calls for independent tasks can be made in parallel.
 
-**Failure handling**: If any TaskCreate call fails during batch creation, report partial results — list successfully registered items with their task IDs and failed items with error reason. Do not silently continue; the user must know which items were not tracked.
+**Failure handling**: If any TaskCreate call fails during batch creation, report partial results:
+- List successfully registered items with their task IDs
+- List failed items with error reason
+- Do not silently continue — the user must know which items were not tracked
 
 After task creation, output a summary showing the count per type with a brief note on each type's expected handling (executable: run now, ci: await pipeline, post-merge: verify after merge, manual: user checks).
 

--- a/task-workflow/skills/task-run/SKILL.md
+++ b/task-workflow/skills/task-run/SKILL.md
@@ -472,7 +472,7 @@ Display a summary when `--all` mode completes or when 2+ tasks were executed:
 - Task count upper bound for sync: 50 total tasks (all statuses, before pending filter). If exceeded, warn and ask before proceeding.
 
 ### Handover Mode
-- Always call AskUserQuestion for component selection — never auto-include all data without user choice.
-- Respect user selection exactly — do not add unselected components to the entry prompt.
-- Include source_session_id in both metadata and description endnote for traceability.
-- Do not call TaskUpdate or TaskDelete — handover is read-only collection plus a single TaskCreate.
+- Handover: always call AskUserQuestion for component selection — never auto-include all data without user choice.
+- Handover: respect user selection exactly — do not add unselected components to the entry prompt.
+- Handover: include source_session_id in both metadata and description endnote for traceability.
+- Handover: do not call TaskUpdate or TaskDelete — handover is read-only collection plus a single TaskCreate.


### PR DESCRIPTION
## Summary

- ship 스킬에서 ci 타입 항목을 task 생성 대상에서 기본 제외 — CI 결과는 `gh pr checks`로 자동 확인 가능하므로 task 추적 overhead 제거
- Phase 3 분류는 유지(투명성), Phase 4에서 opt-in 가능, Phase 5에서 미생성 강제
- task-run Handover rules prefix 일관성 수정

## Test plan

- [x] ship 스킬 실행 시 ci 타입 항목이 Phase 4에서 기본 제외로 표시되는지 확인
- [x] Phase 4에서 ci 항목 opt-in 시 task가 정상 생성되는지 확인
- [x] ci 항목 없이 confirm 시 ci task가 생성되지 않는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

