### PR TITLE
fix(tasks): guard against stale taskListId pointing at a removed dir

### DIFF
--- a/lib/tasks.lua
+++ b/lib/tasks.lua
@@ -161,9 +161,12 @@ function M.loadAllTasks(config, utils, log)
         return tasks
     end
 
-    -- Load specific session or all sessions
+    -- Load specific session or all sessions.
+    -- Guard against a stale taskListId whose directory no longer exists (e.g. an
+    -- old numeric task-list id left over after the per-session directory scheme
+    -- change): fall back to scanning all sessions instead of pinning to a dead path.
     local sessions = {}
-    if config.taskListId then
+    if config.taskListId and utils.fileExists(tasksDir .. "/" .. config.taskListId) then
         sessions = {config.taskListId}
     else
         sessions = utils.listDir(tasksDir)

--- a/lib/utils.lua
+++ b/lib/utils.lua
@@ -27,8 +27,11 @@ end
 -- List directory contents
 function M.listDir(path)
     local items = {}
-    local iter, dir = hs.fs.dir(path)
-    if not iter then return items end
+    -- hs.fs.dir raises (not returns nil) when path is missing/inaccessible,
+    -- so wrap in pcall to fail soft to an empty list instead of crashing the
+    -- caller (e.g. a stale taskListId pointing at a removed task directory).
+    local ok, iter, dir = pcall(hs.fs.dir, path)
+    if not ok or not iter then return items end
     for entry in iter, dir do
         if entry ~= "." and entry ~= ".." then
             table.insert(items, entry)


### PR DESCRIPTION
## Problem

The task viewer crashed on **every** refresh with:

```
.../lib/utils.lua:30: cannot open /Users/choi/.claude/tasks/192: No such file or directory
  [C]: in function 'hs.libfs.dir'
  utils.lua:30 listDir → tasks.lua:135 loadSessionFromDisk → tasks.lua:174 loadAllTasks
  → init.lua:159 refreshWebView → init.lua:347 onChangeCallback → watcher.lua:59
```

### Root cause

`~/.claude/tasks/` migrated from numeric task-list ids (e.g. `192`) to
per-session directories (`session-*` / UUID). A stale `currentTaskListId: "192"`
left in the local `state.json` is re-injected into `config.taskListId` on load,
so `loadAllTasks` takes the single-session branch `{ "192" }` and calls
`listDir("~/.claude/tasks/192")` — a path that no longer exists.

`hs.fs.dir` **raises** (does not return `nil`) on a missing path, so the existing
`if not iter then return items end` guard never fires and the timer callback
crashes on each file-change event.

## Fix (two layers)

- **`utils.listDir`** — wrap `hs.fs.dir` in `pcall`, so a missing/inaccessible
  path fails soft to an empty list instead of raising. Defends every caller.
- **`tasks.loadAllTasks`** — verify the `taskListId` directory exists before
  pinning to it; otherwise fall back to scanning all sessions (graceful instead
  of showing nothing).

The stale `state.json` value itself was cleared out-of-band on the affected
machine (`"192"` → `null`); this PR prevents recurrence and hardens the load path.

## Verification

- `pcall(hs.fs.dir, '.../tasks/192')` → `ok=false` confirms the raise and that
  the new guard catches it.
- `luac -p` passes on both files; spoon reloads cleanly; `config.taskListId` nil.
